### PR TITLE
Add --yes flag to task installing the exact conda version

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,7 +16,7 @@
 
 - name: Update miniconda version (exact)
   command: >-
-    {{ miniconda_prefix }}/bin/conda install
+    {{ miniconda_prefix }}/bin/conda install --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
     {{ miniconda_channels | join(' --channel ') }}
     conda={{ miniconda_version }}


### PR DESCRIPTION
Hi @natefoo I just started using this role and I am using `miniconda_version` != latest.  It needs `--yes` or it will wait.