### PR TITLE
add a task to install packages to base environment

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,11 @@ miniconda_installer_python: null
 # The conda version of the installer
 miniconda_installer_version: latest
 
+# List packages to install into conda's base environment
+# e.g.
+# miniconda_base_env_packages: ['mamba']
+miniconda_base_env_packages: []
+
 # Create environments using the provided description. e.g.:
 #
 # miniconda_conda_environments:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,6 +32,14 @@
   changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
   when: miniconda_version == 'latest'
 
+- name: Install packages to conda base environment
+  command: >-
+    {{ miniconda_prefix }}/bin/conda install --yes
+    {{ '--override-channels --channel' if (miniconda_channels) else '' }}
+    {{ miniconda_channels | join(' --channel ') }}
+    {{ miniconda_base_env_packages | join(' ') }}
+  when: miniconda_base_env_packages
+
 - name: Create conda envs
   command: >-
     {{ miniconda_prefix }}/bin/conda create --yes


### PR DESCRIPTION
Add a task that will install packages into the base environment.  I'd like to install mamba this way.  I tried this first with

```
miniconda_conda_environments:
  base:
    packages:
      - mamba
```
but got the error
"CondaValueError: The target prefix is the base prefix. Aborting."

though I could have been doing it wrong..