### PR TITLE
Add no-cache option to skip storing packages in pkgs/

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,12 +26,19 @@ miniconda_base_env_packages: []
 # Create environments using the provided description. e.g.:
 #
 # miniconda_conda_environments:
-#   python@3.9:
-#     channels:  # optional, defaults to miniconda_channels
+#   python@3.9:        # conda create --name python@3.9 ...
+#     channels:        # optional, defaults to miniconda_channels
 #       - conda-forge
 #       - defaults
+#     copy: false      # use --copy with conda install, optional, defaults to false
+#     no_cache: false  # don't download packages to pkgs/ directory, optional, defaults to false
 #     packages:
 #       - python=3.9
+#   /opt/python@3.10:  # conda create --path /opt/python@3.10
+#     copy: true
+#     packages:
+#       - python=3.10
+#
 miniconda_conda_environments: {}
 
 # Automatically create a conda env using virtualenv from conda-forge for Galaxy (https://galaxyproject.org/)

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -40,19 +40,41 @@
     {{ miniconda_base_env_packages | join(' ') }}
   when: miniconda_base_env_packages
 
-# Apparently item.value.copy always refers to the built-in copy method of the dict, whereas item.value['copy'] only does
-# if the key 'copy' is not defined
-- name: Create conda envs
-  command: >-
-    {{ miniconda_prefix }}/bin/conda create --yes
-    {{ '--override-channels --channel' if (item.value.channels | default(miniconda_channels)) else '' }}
-    {{ (item.value.channels | default(miniconda_channels)) | join(' --channel ') }}
-    {{ '--name ' ~ item.key if not item.key.startswith('/') else '--prefix ' ~ item.key }}
-    {{ '--copy' if (item.value['copy'] is boolean and item.value['copy']) else '' }}
-    {{ item.value.packages | join(' ') }}
-  args:
-    creates: "{{ miniconda_prefix ~ '/envs/' ~ item.key if not item.key.startswith('/') else item.key }}"
-  loop: "{{ miniconda_conda_environments | dict2items }}"
+- name: Conda env block
+  block:
+
+    - name: Create tempdir for $CONDA_PKGS_DIRS
+      tempfile:
+        state: directory
+        suffix: miniconda_pkg_cache
+      when: (miniconda_conda_environments.values() | selectattr('no_cache', 'defined') | selectattr('no_cache', 'truthy')) is truthy
+      changed_when: false
+      register: __miniconda_pkg_cache_tempdir
+
+    # Apparently item.value.copy always refers to the built-in copy method of the dict, whereas item.value['copy'] only
+    # does if the key 'copy' is not defined
+    - name: Create conda envs
+      command: >-
+        {{ miniconda_prefix }}/bin/conda create --yes
+        {{ '--override-channels --channel' if (item.value.channels | default(miniconda_channels)) else '' }}
+        {{ (item.value.channels | default(miniconda_channels)) | join(' --channel ') }}
+        {{ '--name ' ~ item.key if not item.key.startswith('/') else '--prefix ' ~ item.key }}
+        {{ '--copy' if (item.value['copy'] is boolean and item.value['copy']) else '' }}
+        {{ item.value.packages | join(' ') }}
+      args:
+        creates: "{{ miniconda_prefix ~ '/envs/' ~ item.key if not item.key.startswith('/') else item.key }}"
+      loop: "{{ miniconda_conda_environments | dict2items }}"
+      environment:
+        CONDA_PKGS_DIRS: "{{ (item.value.no_cache | default(false)) | ternary(__miniconda_pkg_cache_tempdir.path, '') }}"
+
+  always:
+
+    - name: Remove $CONDA_PKGS_DIRS tempdir
+      file:
+        path: "{{ __miniconda_pkg_cache_tempdir.path }}"
+        state: absent
+      when: __miniconda_pkg_cache_tempdir.path is defined
+      changed_when: false
 
 - name: Update conda envs
   command: >-


### PR DESCRIPTION
When installing Conda for Galaxy, it'd be nice from a privilege separation standpoint to be able to install Conda once for tool deps as the Galaxy user, and then use that same Conda but running as a different user to create a copied, installed-at-a-prefix env as that different user:

```yaml
- hosts: all
  vars:
    miniconda_version: 22.11.1
    miniconda_prefix: /home/nate/ansible/test/conda
    miniconda_channels:
      - conda-forge
      - defaults
    miniconda_conda_environments:
      python@3.8:
        packages:
          - python=3.8
  roles:
    - role: galaxyproject.miniconda
    - role: galaxyproject.miniconda
      become: true
      become_user: natetest
      miniconda_conda_environments:
        /home/natetest/python@3.10:
          copy: true
          no_cache: true
          packages:
            - python=3.10
```

If you tried to do this prior to this change and the other user is root, you'd install things into `pkgs/` as root and break the conda installation for the original user. Interestingly, if the other user is instead some unprivileged user, Conda is smart enough to use `~<otheruser>/.conda/pkgs` instead, so this is really only a problem when running as root. Now that I've discovered this I'm going to look into whether there are any alternatives we can apply just for the root case.

Also `no_cache` should maybe also imply `--use-index-cache` so it doesn't overwrite the cache as root. Although again, if you run as another unprivileged user it can update the cache to `~<otheruser>/.conda/pkgs/cache`, so this would only be a problem for root.

`$CONDA_PKGS_DIRS` usage is per the discussion on https://github.com/conda/conda/issues/7741