### PR TITLE
support different conda distributions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,4 +33,4 @@ jobs:
         run: ansible-lint
 
       - name: Run Ansible Playbook Test
-        run: ansible-playbook tests/test.yml
+        run: ansible-playbook -i tests/inventory tests/test.yml

--- a/README.md
+++ b/README.md
@@ -22,9 +22,16 @@ See [defaults/main.yml](defaults/main.yml) for a full list.
 
 The only required variable is `miniconda_prefix`, the root of the Conda installation.
 
+The following two variables can be used to select the Conda installer and executable
+
+- `miniconda_distribution`: the values can be `miniforge` (default), `miniconda`, `micromamba` or `anaconda`
+- `miniconda_executable`: the default values depend on the value of `miniconda_distribution`
+  - `mamba`: when the distribution is _miniforge_
+  - `micromamba`: when the distribution is _micromamba_
+  - `conda`: when the distribution is _miniconda_ or _anaconda_
+
 To create arbitrary conda environments, use the variable `miniconda_conda_environments` as shown in the defaults, or the
-example below. The role will also run `conda install` to update these environments if you change their list of packages
-or package versions.
+example below. The role will also update these environments if you change their list of packages or package versions.
 
 To create an env named `_galaxy_` for creating a venv for [Galaxy][galaxy], set `galaxy_conda_create_env` to `true`. You
 can then use `{{ miniconda_prefix }}/envs/_galaxy_/bin/virtualenv` as the value to `galaxy_virtualenv_command` in
@@ -45,10 +52,12 @@ Example Playbook
 ```yaml
 - hosts: localhost
   vars:
-    miniconda_prefix: /conda
+    miniconda_prefix: /conda           # required
+    miniconda_distribution: miniforge  # optional
+    miniconda_executable: mamba        # optional
     miniconda_conda_environments:
       python@3.9:
-        channels:  # optional, defaults to miniconda_channels
+        channels:                     # optional, defaults to miniconda_channels
           - conda-forge
           - defaults
         packages:

--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 galaxyproject.miniconda
 =======================
 
-An [Ansible][ansible] role for installing and managing [Miniconda][miniconda] installation. Additionally, the role can
+An [Ansible][ansible] role for installing and managing [Conda][conda] using [Miniforge][miniforge], [micromamba][micromamba], [Miniconda][miniconda] or [Anaconda][anaconda]. Additionally, the role can
 manage the creation of a [Conda][conda] environment that can be used to create a [venv][venv] for [Galaxy][galaxy].
 
+> [!WARNING]
+> Use of Miniconda and Anaconda by those at organizations with more than 200 employees or contractors (including Affiliates) requires a [paid Anaconda Business license](https://www.anaconda.com/pricing).
+
 [ansible]: https://www.ansible.com/
-[miniconda]: https://docs.conda.io/en/latest/miniconda.html
+[miniforge]: https://github.com/conda-forge/miniforge
+[micromamba]: https://github.com/mamba-org/micromamba-releases
+[miniconda]: https://www.anaconda.com/docs/getting-started/miniconda/
+[anaconda]: https://www.anaconda.com/docs/getting-started/anaconda/
 [conda]: https://docs.conda.io/en/latest/
 [venv]: https://docs.python.org/3/tutorial/venv.html
 [galaxy]: https://galaxyproject.org/
@@ -22,10 +28,10 @@ See [defaults/main.yml](defaults/main.yml) for a full list.
 
 The only required variable is `miniconda_prefix`, the root of the Conda installation.
 
-The following two variables can be used to select the Conda installer and executable
+The following two variables can be used to select the Conda installer and executable:
 
-- `miniconda_distribution`: the values can be `miniforge` (default), `miniconda`, `micromamba` or `anaconda`
-- `miniconda_executable`: the default values depend on the value of `miniconda_distribution`
+- `miniconda_distribution`: the values can be `miniforge` (default), `micromamba`, `miniconda` or `anaconda`
+- `miniconda_executable`: the default value depend on the value of `miniconda_distribution`
   - `mamba`: when the distribution is _miniforge_
   - `micromamba`: when the distribution is _micromamba_
   - `conda`: when the distribution is _miniconda_ or _anaconda_

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -150,13 +150,3 @@ miniconda_executable: >-
   {%- else -%}
     conda
   {%- endif -%}
-
-# Executable for installing/updating the installer itself.
-miniconda_version_executable: >-
-  {%- if miniconda_distribution == 'miniforge' -%}
-    mamba
-  {%- elif miniconda_distribution == 'micromamba' -%}
-    micromamba
-  {%- else -%}
-    conda
-  {%- endif -%}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,7 +62,7 @@ miniconda_installer_os: >-
 
 miniconda_installer_arch: "{{ ansible_architecture }}"
 
-# Distruction can be miniconda (default), miniforge, micromamba or anaconda
+# Distribution can be miniconda (default), miniforge, micromamba or anaconda
 miniconda_distribution: "miniconda"
 
 # Examples of installer URL's for the supported distributions:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -153,7 +153,9 @@ miniconda_executable: >-
 
 # Executable for installing/updating the installer itself.
 miniconda_version_executable: >-
-  {%- if miniconda_distribution == 'micromamba' -%}
+  {%- if miniconda_distribution == 'miniforge' -%}
+    mamba
+  {%- elif miniconda_distribution == 'micromamba' -%}
     micromamba
   {%- else -%}
     conda

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,14 +53,108 @@ galaxy_conda_env_packages:
 #
 # ansible_distribution is 'MacOSX' if ansible_system is 'Darwin'
 # ansible_system is 'Linux' on Linux
-miniconda_installer_os: "{{ ansible_distribution if ansible_system == 'Darwin' else ansible_system }}"
+miniconda_installer_os: >-
+  {%- if ansible_system == 'Darwin' -%}
+    MacOSX
+  {%- else -%}
+    {{ ansible_system }}
+  {%- endif -%}
+
 miniconda_installer_arch: "{{ ansible_architecture }}"
-# The installer filename on https://repo.anaconda.com/miniconda/ to fetch and run
+
+# Distruction can be miniconda (default), miniforge, micromamba or anaconda
+miniconda_distribution: "miniconda"
+
+# Examples of installer URL's for the supported distributions:
+#
+#   miniforge:
+#     - https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh
+#     - https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-MacOSX-arm64.sh
+#     - https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-25.3.0-3-Linux-x86_64.sh
+#     - https://github.com/conda-forge/miniforge/releases/download/25.3.0-3/Miniforge3-25.3.0-3-MacOSX-arm64.sh
+#
+#   miniconda:
+#     - https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
+#     - https://repo.anaconda.com/miniconda/Miniconda3-latest-MacOSX-arm64.sh
+#     - https://repo.anaconda.com/miniconda/Miniconda3-py39_25.5.1-0-Linux-x86_64.sh
+#     - https://repo.anaconda.com/miniconda/Miniconda3-py39_25.5.1-0-MacOSX-arm64.sh
+#
+#   anaconda:
+#     - https://repo.anaconda.com/archive/Anaconda3-2025.06-0-Linux-x86_64.sh
+#     - https://repo.anaconda.com/archive/Anaconda3-2025.06-0-MacOSX-arm64.sh
+#
+#   micromamba:
+#     - https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-linux-64.tar.bz2
+#     - https://github.com/mamba-org/micromamba-releases/releases/latest/download/micromamba-osx-arm64.tar.bz2
+#     - https://github.com/mamba-org/micromamba-releases/releases/download/2.3.0-1/micromamba-linux-64.tar.bz2
+#     - https://github.com/mamba-org/micromamba-releases/releases/download/2.3.0-1/micromamba-osx-arm64.tar.bz2
+
+
+# The installer filename (shell script or tarball)
 miniconda_installer: >-
-  Miniconda3-{{
-    'py' ~ (miniconda_python | replace('.', '')) ~ '_' ~ miniconda_version
-    if miniconda_installer_version != 'latest'
-    else 'latest'
-  }}-{{ miniconda_installer_os }}-{{ miniconda_installer_arch }}.sh
+  {%- if miniconda_distribution == 'miniforge' -%}
+    {%- if miniconda_installer_version == 'latest' -%}
+      Miniforge3-{{ miniconda_installer_os }}-{{ miniconda_installer_arch }}.sh
+    {%- else -%}
+      Miniforge3-{{ miniconda_installer_version }}-{{ miniconda_installer_os }}-{{ miniconda_installer_arch }}.sh
+    {%- endif -%}
+  {%- elif miniconda_distribution == 'miniconda' -%}
+    {%- if miniconda_installer_version == 'latest' -%}
+      Miniconda3-latest-{{ miniconda_installer_os }}-{{ miniconda_installer_arch }}.sh
+    {%- else -%}
+      Miniconda3-py{{ miniconda_installer_python | replace('.', '') }}_
+      {{ miniconda_installer_version }}-
+      {{ miniconda_installer_os }}-{{ miniconda_installer_arch }}.sh
+    {%- endif -%}
+  {%- elif miniconda_distribution == 'anaconda' -%}
+    Anaconda3-{{ miniconda_installer_version }}-{{ miniconda_installer_os }}-{{ miniconda_installer_arch }}.sh
+  {%- elif miniconda_distribution == 'micromamba' -%}
+    {%- set micromamba_os_map = {'MacOSX': 'osx', 'Linux': 'linux'} -%}
+    {%- set micromamba_arch_map = {'x86_64': '64', 'aarch64': 'aarch64', 'arm64': 'arm64'} -%}
+    micromamba-{{ micromamba_os_map[miniconda_installer_os] }}-{{ micromamba_arch_map[miniconda_installer_arch] }}.tar.bz2
+  {%- else -%}
+    {{ fail("Invalid value for 'miniconda_distribution': " ~ miniconda_distribution) }}
+  {%- endif -%}
+
+# The installer download URL (shell script or tarball)
+miniconda_installer_url: >-
+  {%- if miniconda_distribution == 'miniforge' -%}
+    {%- if miniconda_installer_version == 'latest' -%}
+      https://github.com/conda-forge/{{ miniconda_distribution }}/releases/latest/download/{{ miniconda_installer }}
+    {%- else -%}
+      https://github.com/conda-forge/{{ miniconda_distribution }}/releases/download/{{ miniconda_installer_version }}/{{ miniconda_installer }}
+    {%- endif -%}
+  {%- elif miniconda_distribution == 'miniconda' -%}
+    https://repo.anaconda.com/miniconda/{{ miniconda_installer }}
+  {%- elif miniconda_distribution == 'anaconda' -%}
+    https://repo.anaconda.com/archive/{{ miniconda_installer }}
+  {%- elif miniconda_distribution == 'micromamba' -%}
+    {%- if miniconda_installer_version == 'latest' -%}
+      https://github.com/mamba-org/{{ miniconda_distribution }}-releases/releases/latest/download/{{ miniconda_installer }}
+    {%- else -%}
+      https://github.com/mamba-org/{{ miniconda_distribution }}-releases/releases/download/{{ miniconda_installer_version }}/{{ miniconda_installer }}
+    {%- endif -%}
+  {%- else -%}
+    {{ fail("Invalid value for 'miniconda_distribution': " ~ miniconda_distribution) }}
+  {%- endif -%}
+
 # The shell to call the downloaded installer script with
 miniconda_installer_shell: /bin/sh
+
+# Executable for installing/updating conda packages.
+miniconda_executable: >-
+  {%- if miniconda_distribution == 'micromamba' -%}
+    micromamba
+  {%- elif miniconda_distribution == 'miniforge' -%}
+    mamba
+  {%- else -%}
+    conda
+  {%- endif -%}
+
+# Executable for installing/updating the installer itself.
+miniconda_version_executable: >-
+  {%- if miniconda_distribution == 'micromamba' -%}
+    micromamba
+  {%- else -%}
+    conda
+  {%- endif -%}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,8 +62,8 @@ miniconda_installer_os: >-
 
 miniconda_installer_arch: "{{ ansible_architecture }}"
 
-# Distribution can be miniconda (default), miniforge, micromamba or anaconda
-miniconda_distribution: "miniconda"
+# Distribution can be miniforge (default), miniconda, micromamba or anaconda
+miniconda_distribution: "miniforge"
 
 # Examples of installer URL's for the supported distributions:
 #
@@ -143,10 +143,10 @@ miniconda_installer_shell: /bin/sh
 
 # Executable for installing/updating conda packages.
 miniconda_executable: >-
-  {%- if miniconda_distribution == 'micromamba' -%}
-    micromamba
-  {%- elif miniconda_distribution == 'miniforge' -%}
+  {%- if miniconda_distribution == 'miniforge' -%}
     mamba
+  {%- elif miniconda_distribution == 'micromamba' -%}
+    micromamba
   {%- else -%}
     conda
   {%- endif -%}

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,29 +1,59 @@
 ---
 
-- name: Create miniconda installer tempfile
+- name: Create installer tempfile (shell script or tarball)
   ansible.builtin.tempfile:
     prefix: ansible-miniconda-installer.
-    suffix: .sh
+    suffix: "{{ '.sh' if miniconda_distribution != 'micromamba' else '.tar.bz2' }}"
   register: miniconda_installer_tempfile
 
-- name: Collect miniconda installer
+- name: Download installer - {{ miniconda_distribution }}
   ansible.builtin.get_url:
-    url: "https://repo.anaconda.com/miniconda/{{ miniconda_installer }}"
+    url: "{{ miniconda_installer_url }}"
     dest: "{{ miniconda_installer_tempfile.path }}"
     force: true
-    mode: "0755"
+    mode: '0755'
 
-- name: Miniconda installer block
+- name: Install Conda distribution (shell installers)
+  when: miniconda_distribution != 'micromamba'
   block:
 
-    - name: Run miniconda installer
-      ansible.builtin.command: "{{ miniconda_installer_shell }} {{ miniconda_installer_tempfile.path }} -b -p {{ miniconda_prefix }}"
-      register: __miniforge_install
-      changed_when: __miniforge_install.rc != 0
+    - name: Install Conda distribution
+      ansible.builtin.command: >
+        {{ miniconda_installer_shell | default('/bin/sh') }}
+        {{ miniconda_installer_tempfile.path }} -b -p {{ miniconda_prefix }}
+      register: __conda_install
+      changed_when: __conda_install.rc != 0
 
   always:
+    - name: Remove installer file
+      ansible.builtin.file:
+        path: "{{ miniconda_installer_tempfile.path }}"
+        state: absent
 
-    - name: Remove minicoda installer
+- name: Install Conda distribution (tarball)
+  when: miniconda_distribution == 'micromamba'
+  block:
+    - name: Create Conda install directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}/bin"
+        state: directory
+        mode: '0755'
+
+    - name: Extract Conda tarball to bin directory
+      ansible.builtin.unarchive:
+        src: "{{ miniconda_installer_tempfile.path }}"
+        dest: "{{ miniconda_prefix }}/bin"
+        remote_src: true
+        extra_opts: [--strip-components=1]
+
+    - name: Ensure micromamba binary is executable
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}/bin/micromamba"
+        mode: '0755'
+        state: file
+
+  always:
+    - name: Remove installer file
       ansible.builtin.file:
         path: "{{ miniconda_installer_tempfile.path }}"
         state: absent

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,7 +11,7 @@
     url: "{{ miniconda_installer_url }}"
     dest: "{{ miniconda_installer_tempfile.path }}"
     force: true
-    mode: '0755'
+    mode: "0755"
 
 - name: Install Conda distribution (shell installers)
   when: miniconda_distribution != 'micromamba'
@@ -37,7 +37,7 @@
       ansible.builtin.file:
         path: "{{ miniconda_prefix }}/bin"
         state: directory
-        mode: '0755'
+        mode: "0755"
 
     - name: Extract Conda tarball to bin directory
       ansible.builtin.unarchive:
@@ -49,7 +49,7 @@
     - name: Ensure micromamba binary is executable
       ansible.builtin.file:
         path: "{{ miniconda_prefix }}/bin/micromamba"
-        mode: '0755'
+        mode: "0755"
         state: file
 
   always:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -19,7 +19,7 @@
 
     - name: Install Conda distribution
       ansible.builtin.command: >
-        {{ miniconda_installer_shell | default('/bin/sh') }}
+        {{ miniconda_installer_shell }}
         {{ miniconda_installer_tempfile.path }} -b -p {{ miniconda_prefix }}
       register: __conda_install
       changed_when: __conda_install.rc != 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,26 +1,37 @@
 ---
 
-- name: Check for miniconda existence
+- name: Fail if miniconda_prefix is not defined
+  ansible.builtin.fail:
+    msg: "'miniconda_prefix' variable is required but not defined."
+  when: miniconda_prefix is not defined
+
+- name: Check for executable existence
   ansible.builtin.stat:
-    path: "{{ miniconda_prefix }}/bin/conda"
-  register: miniconda_exists
+    path: "{{ miniconda_prefix }}/bin/{{ miniconda_executable }}"
+  register: miniconda_exec_info
 
 - name: Include install tasks
   ansible.builtin.include_tasks: install.yml
-  when: miniconda_install and not miniconda_exists.stat.exists
+  when: miniconda_install and not miniconda_exec_info.stat.exists
 
-- name: Collect miniconda version
-  ansible.builtin.command: "{{ miniconda_prefix }}/bin/conda -V"
+- name: Check for executable for version check existence
+  ansible.builtin.stat:
+    path: "{{ miniconda_prefix }}/bin/{{ miniconda_version_executable }}"
+  register: miniconda_version_exec_info
+
+- name: Collect installer version
+  ansible.builtin.command: "{{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} --version"
   register: miniconda_installed_version
   changed_when: false
+  when: miniconda_version_exec_info.stat.exists
 
-- name: Update miniconda
+- name: Update installer
   ansible.builtin.include_tasks: update.yml
-  when: miniconda_update
+  when: miniconda_update and miniconda_version_exec_info.stat.exists
 
 - name: Install packages to conda base environment
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/conda install --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} install --yes
     {{ '--override-channels --channel' if (miniconda_channels) else '' }}
     {{ miniconda_channels | join(' --channel ') }}
     {{ miniconda_base_env_packages | join(' ') }}
@@ -32,7 +43,7 @@
 # if the key 'copy' is not defined
 - name: Create conda envs
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/conda create --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} create --yes
     {{ '--override-channels --channel' if (item.value.channels | default(miniconda_channels)) else '' }}
     {{ (item.value.channels | default(miniconda_channels)) | join(' --channel ') }}
     {{ '--name ' ~ item.key if not item.key.startswith('/') else '--prefix ' ~ item.key }}
@@ -44,7 +55,7 @@
 
 - name: Update conda envs
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/conda install --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} install --yes
     {{ '--override-channels --channel' if (item.value.channels | default(miniconda_channels)) else '' }}
     {{ (item.value.channels | default(miniconda_channels)) | join(' --channel ') }}
     {{ '--name ' ~ item.key if not item.key.startswith('/') else '--prefix ' ~ item.key }}
@@ -56,7 +67,7 @@
 
 - name: Create Galaxy conda env
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/conda create --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} create --yes
     {{ '--override-channels --channel' if galaxy_conda_env_channels else '' }}
     {{ galaxy_conda_env_channels | join(' --channel ') }}
     --name {{ galaxy_conda_env }}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,24 +10,18 @@
     path: "{{ miniconda_prefix }}/bin/{{ miniconda_executable }}"
   register: miniconda_exec_info
 
-- name: Include install tasks
+- name: Install installer
   ansible.builtin.include_tasks: install.yml
   when: miniconda_install and not miniconda_exec_info.stat.exists
 
-- name: Check for executable for version check existence
-  ansible.builtin.stat:
-    path: "{{ miniconda_prefix }}/bin/{{ miniconda_version_executable }}"
-  register: miniconda_version_exec_info
-
 - name: Collect installer version
-  ansible.builtin.command: "{{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} --version"
+  ansible.builtin.command: "{{ miniconda_prefix }}/bin/{{ miniconda_executable }} --version"
   register: miniconda_installed_version
   changed_when: false
-  when: miniconda_version_exec_info.stat.exists
 
 - name: Update installer
   ansible.builtin.include_tasks: update.yml
-  when: miniconda_update and miniconda_version_exec_info.stat.exists
+  when: miniconda_update
 
 - name: Install packages to conda base environment
   ansible.builtin.command: >-

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -1,21 +1,50 @@
 ---
 
-- name: Update miniconda version (exact)
+- name: Update installer version (exact)
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/conda install --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} install --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
     {{ miniconda_channels | join(' --channel ') }}
-    conda={{ miniconda_version }}
+    {{ miniconda_version_executable }}={{ miniconda_version }}
   register: __miniconda_conda_update_conda_output
   changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
-  when: miniconda_version != 'latest' and (miniconda_installed_version.stdout.split() | last) != miniconda_version
+  when:
+    - miniconda_version != 'latest'
+    - miniconda_version_executable != 'micromamba'
+    - (miniconda_installed_version.stdout.split() | last) != miniconda_version
 
-- name: Update miniconda version (latest)
+- name: Update installer version (latest)
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/conda update --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} update --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
     {{ miniconda_channels | join(' --channel ') }}
-    conda
+    {{ miniconda_version_executable }}
   register: __miniconda_conda_update_conda_output
   changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
-  when: miniconda_version == 'latest'
+  when:
+    - miniconda_version == 'latest'
+    - miniconda_version_executable != 'micromamba'
+
+- name: Update installer version (exact)
+  ansible.builtin.command: >-
+    {{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} self-update --yes
+    {{ '--override-channels --channel' if miniconda_channels else '' }}
+    {{ miniconda_channels | join(' --channel ') }}
+    --version {{ miniconda_version }}
+  register: __miniconda_conda_update_conda_output
+  changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
+  when:
+    - miniconda_version != 'latest'
+    - miniconda_version_executable == 'micromamba'
+    - (miniconda_installed_version.stdout.split() | last) != miniconda_version
+
+- name: Update installer version (latest)
+  ansible.builtin.command: >-
+    {{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} self-update --yes
+    {{ '--override-channels --channel' if miniconda_channels else '' }}
+    {{ miniconda_channels | join(' --channel ') }}
+  register: __miniconda_conda_update_conda_output
+  changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
+  when:
+    - miniconda_version == 'latest'
+    - miniconda_version_executable == 'micromamba'

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -2,32 +2,32 @@
 
 - name: Update installer version (exact)
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} install --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} install --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
     {{ miniconda_channels | join(' --channel ') }}
-    {{ miniconda_version_executable }}={{ miniconda_version }}
+    {{ miniconda_executable }}={{ miniconda_version }}
   register: __miniconda_conda_update_conda_output
   changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
   when:
     - miniconda_version != 'latest'
-    - miniconda_version_executable != 'micromamba'
+    - miniconda_executable != 'micromamba'
     - (miniconda_installed_version.stdout.split() | last) != miniconda_version
 
 - name: Update installer version (latest)
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} update --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} update --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
     {{ miniconda_channels | join(' --channel ') }}
-    {{ miniconda_version_executable }}
+    {{ miniconda_executable }}
   register: __miniconda_conda_update_conda_output
   changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
   when:
     - miniconda_version == 'latest'
-    - miniconda_version_executable != 'micromamba'
+    - miniconda_executable != 'micromamba'
 
 - name: Update installer version (exact)
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} self-update --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} self-update --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
     {{ miniconda_channels | join(' --channel ') }}
     --version {{ miniconda_version }}
@@ -35,16 +35,16 @@
   changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
   when:
     - miniconda_version != 'latest'
-    - miniconda_version_executable == 'micromamba'
+    - miniconda_executable == 'micromamba'
     - (miniconda_installed_version.stdout.split() | last) != miniconda_version
 
 - name: Update installer version (latest)
   ansible.builtin.command: >-
-    {{ miniconda_prefix }}/bin/{{ miniconda_version_executable }} self-update --yes
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} self-update --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
     {{ miniconda_channels | join(' --channel ') }}
   register: __miniconda_conda_update_conda_output
   changed_when: "'All requested packages already installed' not in __miniconda_conda_update_conda_output.stdout"
   when:
     - miniconda_version == 'latest'
-    - miniconda_version_executable == 'micromamba'
+    - miniconda_executable == 'micromamba'

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,2 +1,1 @@
-localhost
-
+localhost ansible_connection=local

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,8 +1,104 @@
 ---
+
 - name: Test with defaults
   hosts: localhost
-  remote_user: root
   vars:
     miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
-  roles:
-    - ansible-miniconda
+  tasks:
+    - name: Run ansible-miniconda role with defaults
+      ansible.builtin.include_role:
+        name: ansible-miniconda
+
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent
+
+- name: Test with miniforge
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+  tasks:
+    - name: Run ansible-miniconda role with miniforge
+      ansible.builtin.include_role:
+        name: ansible-miniconda
+      vars:
+        miniconda_distribution: "miniforge"
+        miniconda_conda_environments:
+          test_env:
+            channels:
+              - conda-forge
+            packages:
+              - zlib
+
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent
+
+- name: Test with miniconda
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+  tasks:
+    - name: Run ansible-miniconda role with miniconda
+      ansible.builtin.include_role:
+        name: ansible-miniconda
+      vars:
+        miniconda_distribution: "miniconda"
+        miniconda_conda_environments:
+          test_env:
+            channels:
+              - conda-forge
+            packages:
+              - zlib
+
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent
+
+- name: Test with anaconda
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+  tasks:
+    - name: Run ansible-miniconda role with anaconda
+      ansible.builtin.include_role:
+        name: ansible-miniconda
+      vars:
+        miniconda_distribution: "anaconda"
+        miniconda_installer_version: "2025.06-0"
+        miniconda_conda_environments:
+          test_env:
+            channels:
+              - conda-forge
+            packages:
+              - zlib
+
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent
+
+- name: Test with micromamba
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+  tasks:
+    - name: Run ansible-miniconda role with micromamba
+      ansible.builtin.include_role:
+        name: ansible-miniconda
+      vars:
+        miniconda_distribution: "micromamba"
+        miniconda_conda_environments:
+          test_env:
+            channels:
+              - conda-forge
+            packages:
+              - zlib
+
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent


### PR DESCRIPTION
Closes #6

This PR adds support for miniforge, miniconda, micromamba and anaconda. miniforge is the default.

## Variables

Variables that depend on the distribution

- _miniconda_distribution_ (**new**): miniforge, miniconda, micromamba and anaconda
- _miniconda_executable_ (**new**): for installing conda packages and self-updating (mamba, conda, micromamba)
- _miniconda_installer_: shell script or tarball file name
- _miniconda_installer_url_ (**new**): full shell script or tarball URL

I kept the variables names with the _miniconda__ prefix because the role is called miniconda (linting requires it), despite the fact that it is not miniconda specific anymore after this PR.

## Tasks

- _install.yml:_ in addition to shell scripts, handle tarballs as well (assume unpacking is enough)
- _update.yml_: micromamba has a slightly different way of self-updating than conda
- _main.yml_: no logical changes

## Tests

Add integration tests for all distributions.