### PR TITLE
Add opt-in ToS acceptance of conda channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-galaxyproject.miniconda
-=======================
+# galaxyproject.miniconda
 
 An [Ansible][ansible] role for installing and managing [Conda][conda] using [Miniforge][miniforge], [micromamba][micromamba], [Miniconda][miniconda] or [Anaconda][anaconda]. Additionally, the role can
 manage the creation of a [Conda][conda] environment that can be used to create a [venv][venv] for [Galaxy][galaxy].
@@ -16,13 +15,11 @@ manage the creation of a [Conda][conda] environment that can be used to create a
 [venv]: https://docs.python.org/3/tutorial/venv.html
 [galaxy]: https://galaxyproject.org/
 
-Requirements
-------------
+## Requirements
 
 A [Conda][conda]-compatible version of Linux or macOS is required.
 
-Role Variables
---------------
+## Role Variables
 
 See [defaults/main.yml](defaults/main.yml) for a full list.
 
@@ -47,28 +44,48 @@ distributions and versions.
 
 [galaxy-role]: https://github.com/galaxyproject/ansible-galaxy
 
-Terms of Service (ToS) for Conda Channels
-+++++++++++++++++++++++++++++++++++++++++
+## Terms of Service (ToS) for Conda Channels
 
-Some Conda channels require explicit acceptance of their Terms of Service (ToS).
+Some Conda channels require explicit acceptance of their Terms of Service (ToS) before you can use them.
 
-Use the `miniconda_tos_channels` variable to list the channels for which the role should pre-accept the ToS:
+### Configuring ToS Acceptance
+
+You can pre-accept the ToS for specific channels by setting the following variables in your playbook or inventory:
 
 ```yaml
 miniconda_tos_channels:
   - https://repo.anaconda.com/pkgs/main
   - https://repo.anaconda.com/pkgs/r
+
+miniconda_tos_packages:
+  - conda-anaconda-tos  # required for Miniforge and older versions of Miniconda/Anaconda
 ```
 
-These are currently required when `miniconda_distribution: miniconda`.
+> **Important:** The `galaxyproject.miniconda` role **does not accept any Terms of Service automatically**.
+> If you need to use channels that require ToS acceptance, you must configure the variables above explicitly.
 
-Dependencies
-------------
+### Legal Note
+
+Packages from these `main` and `r` channels are subject to the
+[Anaconda Repository Terms of Service](https://www.anaconda.com/legal/terms/terms-of-service).
+
+Among other restrictions, the ToS prohibits:
+
+* heavy commercial use without a license, and
+* mirroring by third parties for commercial purposes.
+
+### ToS Support by Distribution
+
+* `miniconda`: Supported out of the box in recent versions.
+* `anaconda`: Supported out of the box in recent versions.
+* `miniforge`: Supported when `miniconda_tos_packages: [conda-anaconda-tos]` is defined.
+* `micromamba`: Not supported.
+
+## Dependencies
 
 None
 
-Example Playbook
-----------------
+## Example Playbook
 
 ```yaml
 - hosts: localhost
@@ -88,12 +105,10 @@ Example Playbook
      - galaxyproject.miniconda
 ```
 
-License
--------
+## License
 
 MIT
 
-Author Information
-------------------
+## Author Information
 
 [View contributors on GitHub](https://github.com/galaxyproject/ansible-miniconda/graphs/contributors)

--- a/README.md
+++ b/README.md
@@ -47,6 +47,21 @@ distributions and versions.
 
 [galaxy-role]: https://github.com/galaxyproject/ansible-galaxy
 
+Terms of Service (ToS) for Conda Channels
++++++++++++++++++++++++++++++++++++++++++
+
+Some Conda channels require explicit acceptance of their Terms of Service (ToS).
+
+Use the `miniconda_tos_channels` variable to list the channels for which the role should pre-accept the ToS:
+
+```yaml
+miniconda_tos_channels:
+  - https://repo.anaconda.com/pkgs/main
+  - https://repo.anaconda.com/pkgs/r
+```
+
+These are currently required when `miniconda_distribution: miniconda`.
+
 Dependencies
 ------------
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,16 @@ miniconda_version: latest
 # `conda install conda...` or `conda update conda`.
 miniconda_channels: []
 
+# List of channels for which the Anaconda Terms of Service (ToS) should be accepted.
+# If left empty (default), no ToS acceptance will be attempted.
+#
+# Example:
+# miniconda_tos_channels:
+#   - https://repo.anaconda.com/pkgs/main
+#   - https://repo.anaconda.com/pkgs/r
+#
+miniconda_tos_channels: []
+
 # Use a specific installer version and python version. The default is to use the latest installer. If you specify a
 # version, it must exist in https://repo.anaconda.com/miniconda/
 #

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,11 @@ miniconda_installer_version: latest
 # miniconda_base_env_packages: ['mamba']
 miniconda_base_env_packages: []
 
+# List packages to install into conda's base environment for Tos support
+# e.g.
+# miniconda_tos_packages: ['conda-anaconda-tos']
+miniconda_tos_packages: []
+
 # Create environments using the provided description. e.g.:
 #
 # miniconda_conda_environments:
@@ -160,3 +165,7 @@ miniconda_executable: >-
   {%- else -%}
     conda
   {%- endif -%}
+
+# Executable for acccepting the Terms of Service of the
+# channels provided by miniconda_tos_channels
+miniconda_tos_executable: "{{ 'conda' if miniconda_distribution != 'micromamba' else '' }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,10 @@
   register: miniconda_installed_version
   changed_when: false
 
+- name: Accept Anaconda Terms of Service (ToS)
+  ansible.builtin.include_tasks: tos.yml
+  when: miniconda_tos_channels | length > 0
+
 - name: Update installer
   ansible.builtin.include_tasks: update.yml
   when: miniconda_update

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,16 @@
   register: miniconda_installed_version
   changed_when: false
 
+- name: Install ToS packages to conda base environment
+  ansible.builtin.command: >-
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} install --yes
+    {{ '--override-channels --channel' if (miniconda_tos_channels) else '' }}
+    {{ miniconda_tos_channels | join(' --channel ') }}
+    {{ miniconda_tos_packages | join(' ') }}
+  register: __miniconda_conda_install_conda_output
+  changed_when: "'All requested packages already installed' not in __miniconda_conda_install_conda_output.stdout"
+  when: miniconda_tos_packages | length > 0
+
 - name: Accept Anaconda Terms of Service (ToS)
   ansible.builtin.include_tasks: tos.yml
   when: miniconda_tos_channels | length > 0

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -31,7 +31,7 @@
     {{ miniconda_base_env_packages | join(' ') }}
   register: __miniconda_conda_install_conda_output
   changed_when: "'All requested packages already installed' not in __miniconda_conda_install_conda_output.stdout"
-  when: miniconda_base_env_packages
+  when: miniconda_base_env_packages | length > 0
 
 # Apparently item.value.copy always refers to the built-in copy method of the dict, whereas item.value['copy'] only does
 # if the key 'copy' is not defined

--- a/tasks/tos.yml
+++ b/tasks/tos.yml
@@ -1,16 +1,20 @@
-- name: Check if `conda tos` is available
-  ansible.builtin.command: "{{ miniconda_prefix }}/bin/{{ miniconda_executable }} tos --help"
-  register: __miniconda_tos_check
-  changed_when: false
-  failed_when: false
+- name: Warn if channels are provided but tos is not supported
+  ansible.builtin.debug:
+    msg: >
+      Channels were provided ({{ miniconda_tos_channels }})
+      but no `miniconda_tos_executable` was defined.
+      Terms of Service cannot be accepted.
+  when:
+    - miniconda_tos_channels | length > 0
+    - miniconda_tos_executable | length == 0
 
 - name: Accept Terms of Service for provided channels
   ansible.builtin.command: >
-    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} tos accept
+    {{ miniconda_prefix }}/bin/{{ miniconda_tos_executable }} tos accept
     --override-channels --channel {{ item }}
   args:
     creates: "{{ miniconda_prefix }}/.conda_tos_{{ item | regex_replace('[^a-zA-Z0-9]', '_') }}"
   loop: "{{ miniconda_tos_channels | default([]) }}"
   when:
     - miniconda_tos_channels | length > 0
-    - __miniconda_tos_check.rc == 0
+    - miniconda_tos_executable | length > 0

--- a/tasks/tos.yml
+++ b/tasks/tos.yml
@@ -1,0 +1,16 @@
+- name: Check if `conda tos` is available
+  ansible.builtin.command: "{{ miniconda_prefix }}/bin/{{ miniconda_executable }} tos --help"
+  register: __miniconda_tos_check
+  changed_when: false
+  failed_when: false
+
+- name: Accept Terms of Service for provided channels
+  ansible.builtin.command: >
+    {{ miniconda_prefix }}/bin/{{ miniconda_executable }} tos accept
+    --override-channels --channel {{ item }}
+  args:
+    creates: "{{ miniconda_prefix }}/.conda_tos_{{ item | regex_replace('[^a-zA-Z0-9]', '_') }}"
+  loop: "{{ miniconda_tos_channels | default([]) }}"
+  when:
+    - miniconda_tos_channels | length > 0
+    - __miniconda_tos_check.rc == 0

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -46,6 +46,9 @@
         name: ansible-miniconda
       vars:
         miniconda_distribution: "miniconda"
+        miniconda_tos_channels:
+          - https://repo.anaconda.com/pkgs/main
+          - https://repo.anaconda.com/pkgs/r
         miniconda_conda_environments:
           test_env:
             channels:

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -24,6 +24,11 @@
         name: ansible-miniconda
       vars:
         miniconda_distribution: "miniforge"
+        miniconda_tos_channels:
+          - https://repo.anaconda.com/pkgs/main
+          - https://repo.anaconda.com/pkgs/r
+        miniconda_tos_packages:
+          - conda-anaconda-tos
         miniconda_conda_environments:
           test_env:
             channels:
@@ -72,6 +77,9 @@
       vars:
         miniconda_distribution: "anaconda"
         miniconda_installer_version: "2025.06-0"
+        miniconda_tos_channels:
+          - https://repo.anaconda.com/pkgs/main
+          - https://repo.anaconda.com/pkgs/r
         miniconda_conda_environments:
           test_env:
             channels:
@@ -94,6 +102,9 @@
         name: ansible-miniconda
       vars:
         miniconda_distribution: "micromamba"
+        miniconda_tos_channels:
+          - https://repo.anaconda.com/pkgs/main
+          - https://repo.anaconda.com/pkgs/r
         miniconda_conda_environments:
           test_env:
             channels:


### PR DESCRIPTION
Closes #14 #13 

Since ansible-core-2.19.2 a conditional expression must result in a boolean.

To make the unit tests pass I also added a parameter to accept the ToS of specific channels. By default we don't agree to anything and we shouldn't imo.