### PR TITLE
allow role run in check mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,5 +32,20 @@ jobs:
       - name: Run ansible-lint
         run: ansible-lint
 
-      - name: Run Ansible Playbook Test
+      - name: Test dry-run before deployment
+        run: ansible-playbook -i tests/inventory tests/test.yml --check --diff | tee /dev/stderr | awk '/changed=[0]/ { exit 1 }'
+
+      - name: Test first deployment
         run: ansible-playbook -i tests/inventory tests/test.yml
+
+      - name: Test dry-run after deployment
+        run: ansible-playbook -i tests/inventory tests/test.yml --check --diff | tee /dev/stderr | awk '/changed=[1-9]/ { exit 1 }'
+
+      - name: Test re-deployment
+        run: ansible-playbook -i tests/inventory tests/test.yml
+
+      - name: Test dry-run after re-deployment
+        run: ansible-playbook -i tests/inventory tests/test.yml --check --diff | tee /dev/stderr | awk '/changed=[1-9]/ { exit 1 }'
+
+      - name: Test cleanup
+        run: ansible-playbook -i tests/inventory tests/cleanup.yml

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -12,6 +12,7 @@
     dest: "{{ miniconda_installer_tempfile.path }}"
     force: true
     mode: "0755"
+  when: not ansible_check_mode
 
 - name: Install Conda distribution (shell installers)
   when: miniconda_distribution != 'micromamba'
@@ -21,18 +22,21 @@
       ansible.builtin.command: >
         {{ miniconda_installer_shell }}
         {{ miniconda_installer_tempfile.path }} -b -p {{ miniconda_prefix }}
-      register: __conda_install
-      changed_when: __conda_install.rc != 0
+      register: __miniconda_conda_install
+      changed_when: __miniconda_conda_install.rc == 0
+      when: not ansible_check_mode
 
   always:
     - name: Remove installer file
       ansible.builtin.file:
         path: "{{ miniconda_installer_tempfile.path }}"
         state: absent
+      when: not ansible_check_mode
 
 - name: Install Conda distribution (tarball)
   when: miniconda_distribution == 'micromamba'
   block:
+
     - name: Create Conda install directory
       ansible.builtin.file:
         path: "{{ miniconda_prefix }}/bin"
@@ -45,15 +49,18 @@
         dest: "{{ miniconda_prefix }}/bin"
         remote_src: true
         extra_opts: [--strip-components=1]
+      when: not ansible_check_mode
 
     - name: Ensure micromamba binary is executable
       ansible.builtin.file:
         path: "{{ miniconda_prefix }}/bin/micromamba"
         mode: "0755"
         state: file
+      when: not ansible_check_mode
 
   always:
     - name: Remove installer file
       ansible.builtin.file:
         path: "{{ miniconda_installer_tempfile.path }}"
         state: absent
+      when: not ansible_check_mode

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,6 +5,8 @@
     msg: "'miniconda_prefix' variable is required but not defined."
   when: miniconda_prefix is not defined
 
+# ---- Conda installer ----
+
 - name: Check for executable existence
   ansible.builtin.stat:
     path: "{{ miniconda_prefix }}/bin/{{ miniconda_executable }}"
@@ -12,12 +14,17 @@
 
 - name: Install installer
   ansible.builtin.include_tasks: install.yml
-  when: miniconda_install and not miniconda_exec_info.stat.exists
+  when:
+    - miniconda_install
+    - not miniconda_exec_info.stat.exists
 
 - name: Collect installer version
   ansible.builtin.command: "{{ miniconda_prefix }}/bin/{{ miniconda_executable }} --version"
   register: miniconda_installed_version
   changed_when: false
+  failed_when:
+    - not ansible_check_mode
+    - miniconda_installed_version.rc != 0
 
 - name: Install ToS packages to conda base environment
   ansible.builtin.command: >-
@@ -27,15 +34,21 @@
     {{ miniconda_tos_packages | join(' ') }}
   register: __miniconda_conda_install_conda_output
   changed_when: "'All requested packages already installed' not in __miniconda_conda_install_conda_output.stdout"
-  when: miniconda_tos_packages | length > 0
+  when:
+    - miniconda_tos_packages | length > 0
+    - not ansible_check_mode
 
 - name: Accept Anaconda Terms of Service (ToS)
   ansible.builtin.include_tasks: tos.yml
-  when: miniconda_tos_channels | length > 0
+  when:
+    - miniconda_tos_channels | length > 0
 
 - name: Update installer
   ansible.builtin.include_tasks: update.yml
-  when: miniconda_update
+  when:
+    - miniconda_update
+
+# ---- Conda base environment ----
 
 - name: Install packages to conda base environment
   ansible.builtin.command: >-
@@ -45,7 +58,11 @@
     {{ miniconda_base_env_packages | join(' ') }}
   register: __miniconda_conda_install_conda_output
   changed_when: "'All requested packages already installed' not in __miniconda_conda_install_conda_output.stdout"
-  when: miniconda_base_env_packages | length > 0
+  when:
+    - miniconda_base_env_packages | length > 0
+    - not ansible_check_mode
+
+# ---- Conda environments ----
 
 # Apparently item.value.copy always refers to the built-in copy method of the dict, whereas item.value['copy'] only does
 # if the key 'copy' is not defined
@@ -60,6 +77,7 @@
   args:
     creates: "{{ miniconda_prefix ~ '/envs/' ~ item.key if not item.key.startswith('/') else item.key }}"
   loop: "{{ miniconda_conda_environments | dict2items }}"
+  when: not ansible_check_mode
 
 - name: Update conda envs
   ansible.builtin.command: >-
@@ -69,9 +87,12 @@
     {{ '--name ' ~ item.key if not item.key.startswith('/') else '--prefix ' ~ item.key }}
     {{ '--copy' if (item.value['copy'] is boolean and item.value['copy']) else '' }}
     {{ item.value.packages | join(' ') }}
-  register: __miniconda_conda_install_output
-  changed_when: "'All requested packages already installed' not in __miniconda_conda_install_output.stdout"
+  register: __miniconda_conda_install_conda_output
+  changed_when: "'All requested packages already installed' not in __miniconda_conda_install_conda_output.stdout"
   loop: "{{ miniconda_conda_environments | dict2items }}"
+  when: not ansible_check_mode
+
+# ---- Galaxy Conda environment ----
 
 - name: Create Galaxy conda env
   ansible.builtin.command: >-
@@ -82,4 +103,6 @@
     {{ galaxy_conda_env_packages | join(' ') }}
   args:
     creates: "{{ miniconda_prefix }}/envs/{{ galaxy_conda_env }}"
-  when: galaxy_conda_create_env
+  when:
+    - galaxy_conda_create_env
+    - not ansible_check_mode

--- a/tasks/tos.yml
+++ b/tasks/tos.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Warn if channels are provided but tos is not supported
   ansible.builtin.debug:
     msg: >
@@ -18,3 +20,4 @@
   when:
     - miniconda_tos_channels | length > 0
     - miniconda_tos_executable | length > 0
+    - not ansible_check_mode

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -11,7 +11,10 @@
   when:
     - miniconda_version != 'latest'
     - miniconda_executable != 'micromamba'
-    - (miniconda_installed_version.stdout.split() | last) != miniconda_version
+    - miniconda_installed_version is defined
+    - miniconda_installed_version.stdout | default('') | length > 0
+    - (miniconda_installed_version.stdout.split() | last | default('missing')) != miniconda_version
+    - not ansible_check_mode
 
 - name: Update installer version (latest)
   ansible.builtin.command: >-
@@ -24,8 +27,9 @@
   when:
     - miniconda_version == 'latest'
     - miniconda_executable != 'micromamba'
+    - not ansible_check_mode
 
-- name: Update installer version (exact)
+- name: Update installer version (exact, micromamba)
   ansible.builtin.command: >-
     {{ miniconda_prefix }}/bin/{{ miniconda_executable }} self-update --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
@@ -36,9 +40,12 @@
   when:
     - miniconda_version != 'latest'
     - miniconda_executable == 'micromamba'
-    - (miniconda_installed_version.stdout.split() | last) != miniconda_version
+    - miniconda_installed_version is defined
+    - miniconda_installed_version.stdout | default('') | length > 0
+    - (miniconda_installed_version.stdout.split() | last | default('missing')) != miniconda_version
+    - not ansible_check_mode
 
-- name: Update installer version (latest)
+- name: Update installer version (latest, micromamba)
   ansible.builtin.command: >-
     {{ miniconda_prefix }}/bin/{{ miniconda_executable }} self-update --yes
     {{ '--override-channels --channel' if miniconda_channels else '' }}
@@ -48,3 +55,4 @@
   when:
     - miniconda_version == 'latest'
     - miniconda_executable == 'micromamba'
+    - not ansible_check_mode

--- a/tests/cleanup.yml
+++ b/tests/cleanup.yml
@@ -1,0 +1,51 @@
+---
+
+- name: Cleanup defaults
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/default"
+  tasks:
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent
+
+- name: Cleanup miniforge
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/miniforge"
+  tasks:
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent
+
+- name: Cleanup miniconda
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/miniconda"
+  tasks:
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent
+
+- name: Cleanup anaconda
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/anaconda"
+  tasks:
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent
+
+- name: Cleanup micromamba
+  hosts: localhost
+  vars:
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/micromamba"
+  tasks:
+    - name: Cleanup conda prefix directory
+      ansible.builtin.file:
+        path: "{{ miniconda_prefix }}"
+        state: absent

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -3,21 +3,16 @@
 - name: Test with defaults
   hosts: localhost
   vars:
-    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/default"
   tasks:
     - name: Run ansible-miniconda role with defaults
       ansible.builtin.include_role:
         name: ansible-miniconda
 
-    - name: Cleanup conda prefix directory
-      ansible.builtin.file:
-        path: "{{ miniconda_prefix }}"
-        state: absent
-
 - name: Test with miniforge
   hosts: localhost
   vars:
-    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/miniforge"
   tasks:
     - name: Run ansible-miniconda role with miniforge
       ansible.builtin.include_role:
@@ -36,15 +31,10 @@
             packages:
               - zlib
 
-    - name: Cleanup conda prefix directory
-      ansible.builtin.file:
-        path: "{{ miniconda_prefix }}"
-        state: absent
-
 - name: Test with miniconda
   hosts: localhost
   vars:
-    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/miniconda"
   tasks:
     - name: Run ansible-miniconda role with miniconda
       ansible.builtin.include_role:
@@ -61,15 +51,10 @@
             packages:
               - zlib
 
-    - name: Cleanup conda prefix directory
-      ansible.builtin.file:
-        path: "{{ miniconda_prefix }}"
-        state: absent
-
 - name: Test with anaconda
   hosts: localhost
   vars:
-    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/anaconda"
   tasks:
     - name: Run ansible-miniconda role with anaconda
       ansible.builtin.include_role:
@@ -87,15 +72,10 @@
             packages:
               - zlib
 
-    - name: Cleanup conda prefix directory
-      ansible.builtin.file:
-        path: "{{ miniconda_prefix }}"
-        state: absent
-
 - name: Test with micromamba
   hosts: localhost
   vars:
-    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda"
+    miniconda_prefix: "{{ lookup('env', 'TRAVIS_BUILD_DIR') | default('/tmp', true) }}/conda/micromamba"
   tasks:
     - name: Run ansible-miniconda role with micromamba
       ansible.builtin.include_role:
@@ -111,8 +91,3 @@
               - conda-forge
             packages:
               - zlib
-
-    - name: Cleanup conda prefix directory
-      ansible.builtin.file:
-        path: "{{ miniconda_prefix }}"
-        state: absent


### PR DESCRIPTION
Closes #17

Not every command has a way to dry-run it, in which case we skip it for dry runs: `when: not ansible_check_mode`.